### PR TITLE
Add searchsortednext and searchsortedprevious

### DIFF
--- a/src/SearchSortedNearest.jl
+++ b/src/SearchSortedNearest.jl
@@ -1,6 +1,6 @@
 module SearchSortedNearest
 
-export searchsortednearest
+export searchsortednearest, searchsortednext, searchsortedprevious
 
 # from: https://discourse.julialang.org/t/findnearest-function/4143/5
 """
@@ -34,7 +34,7 @@ function searchsortednext(a, x; by=identity, lt=isless, rev=false, distance=(a,b
     elseif i > length(a)
         i = length(a)
     else
-        i = i + 1
+        i = i
     end
     return i
 end

--- a/src/SearchSortedNearest.jl
+++ b/src/SearchSortedNearest.jl
@@ -28,4 +28,26 @@ function searchsortednearest(a, x; by=identity, lt=isless, rev=false, distance=(
     return i
 end
 
+function searchsortednext(a, x; by=identity, lt=isless, rev=false, distance=(a,b)->abs(a-b))
+    i = searchsortedfirst(a, x; by, lt, rev)
+    if i == 1
+    elseif i > length(a)
+        i = length(a)
+    else
+        i = i + 1
+    end
+    return i
+end
+
+function searchsortedprevious(a, x; by=identity, lt=isless, rev=false, distance=(a,b)->abs(a-b))
+    i = searchsortedfirst(a, x; by, lt, rev)
+    if i == 1
+    elseif i > length(a)
+        i = length(a)
+    else
+        i = i - 1
+    end
+    return i
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,4 +40,34 @@ using Test
             @test searchsortednearest(reverse(a), x, rev=true) == argmin(abs.(reverse(a) .- x))
         end
     end
+    @testset "searchsortedprev" begin
+        @testset "range" begin
+            A = sort(rand(-100:0.25:100, 20)); 
+            RNG=rand(-100:0.25:100, 20)
+            # @info "set = $A"
+            for rng in RNG
+                ind_method1 = searchsortedprevious(A, rng)
+                ind_method2 = searchsortedfirst(rng .<= A, true) - 1
+                # @info "test" rng
+                @test ind_method1 == ind_method2
+            end
+        end
+        @testset "groundtruth" begin
+            @test all(searchsortedprevious.([collect(0.25:1:10.25)], 1:10) .== collect(1:10))
+        end
+    end
+    @testset "searchsortednext" begin
+        @testset "range" begin
+            A = sort(rand(-100:0.25:100, 20)); 
+            RNG=rand(-100:0.25:100, 20);
+            for rng in RNG
+                ind_method1 = searchsortednext(A, rng)
+                ind_method2 = searchsortedfirst(rng .<= A, true)
+                @test ind_method1 == ind_method2
+            end
+        end
+        @testset "groundtruth" begin
+            @test all(searchsortednext.([collect(0.75:1:10.75)], 1:10) .== (1 .+ collect(1:10)))
+        end
+    end
 end


### PR DESCRIPTION
Adding `searchsortednext` and `searchsortedprevious`

Two common tasks involving finding the nearest point, but not the same: finding the "nearest but greater than point", ie next point, or "nearest but smaller than point", ie previous point. I added two methods for those. 

We often use that sort of functionality in animal behavior data when we want a label corresponding to the beginning or the end of a trial.

It's true that one could type `searchsortedfirst(search_item .<= sorted_list, true)` to find the nearest next point or `searchsortedfirst(search_item .<= sorted_list, true) -1` to find the previous. But encountering lines like those in someone else's code can be opaque. Better to have a function that more or less documents the action taken. Hence why it's nice to have these.

It's also worth mentioning that there's some precedence for these modes in other languages. Matlab's `interp1` has method=`nearest` setting, but also `next` and `previous`. (see https://www.mathworks.com/help/matlab/ref/interp1.html#btwp6lt-1-method)