### PR TITLE
Fix to the CI tests I submitted

### DIFF
--- a/src/SearchSortedNearest.jl
+++ b/src/SearchSortedNearest.jl
@@ -32,7 +32,7 @@ function searchsortednext(a, x; by=identity, lt=isless, rev=false, distance=(a,b
     i = searchsortedfirst(a, x; by, lt, rev)
     if i == 1
     elseif i > length(a)
-        i = length(a)
+        i = nothing
     else
         i = i
     end
@@ -42,6 +42,9 @@ end
 function searchsortedprevious(a, x; by=identity, lt=isless, rev=false, distance=(a,b)->abs(a-b))
     i = searchsortedfirst(a, x; by, lt, rev)
     if i == 1
+        if x < a[i]
+            i = nothing
+        end
     elseif i > length(a)
         i = length(a)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,8 @@ using Test
             # @info "set = $A"
             for rng in RNG
                 ind_method1 = searchsortedprevious(A, rng)
-                ind_method2 = max(searchsortedfirst(rng .<= A, true) - 1, 1)
+                ind_method2 = searchsortedfirst(rng .<= A, true) - 1
+                ind_method2 = ind_method2 == 0 ? nothing : ind_method2
                 # @info "test" rng
                 @test ind_method1 == ind_method2
             end
@@ -62,7 +63,9 @@ using Test
             RNG=rand(-100:0.25:100, 20);
             for rng in RNG
                 ind_method1 = searchsortednext(A, rng)
-                ind_method2 = min(searchsortedfirst(rng .<= A, true),length(A))
+                ind_method2 = searchsortedfirst(rng .<= A, true)
+                ind_method2 = ind_method2 > length(A) ? nothing :
+                              ind_method2
                 @test ind_method1 == ind_method2
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,7 @@ using Test
             for rng in RNG
                 ind_method1 = searchsortedprevious(A, rng)
                 ind_method2 = searchsortedfirst(rng .<= A, true) - 1
-                ind_method2 = ind_method2 == 0 && rng !== A ? nothing : ind_method2
+                ind_method2 = ind_method2 == 0 && rng != A ? nothing : ind_method2
                 # @info "test" rng
                 @test ind_method1 == ind_method2
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,7 @@ using Test
             for rng in RNG
                 ind_method1 = searchsortedprevious(A, rng)
                 ind_method2 = searchsortedfirst(rng .<= A, true) - 1
-                ind_method2 = ind_method2 == 0 ? nothing : ind_method2
+                ind_method2 = ind_method2 == 0 && rng !== A ? nothing : ind_method2
                 # @info "test" rng
                 @test ind_method1 == ind_method2
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ using Test
             # @info "set = $A"
             for rng in RNG
                 ind_method1 = searchsortedprevious(A, rng)
-                ind_method2 = searchsortedfirst(rng .<= A, true) - 1
+                ind_method2 = max(searchsortedfirst(rng .<= A, true) - 1, 1)
                 # @info "test" rng
                 @test ind_method1 == ind_method2
             end
@@ -62,7 +62,7 @@ using Test
             RNG=rand(-100:0.25:100, 20);
             for rng in RNG
                 ind_method1 = searchsortednext(A, rng)
-                ind_method2 = searchsortedfirst(rng .<= A, true)
+                ind_method2 = min(searchsortedfirst(rng .<= A, true),length(A))
                 @test ind_method1 == ind_method2
             end
         end


### PR DESCRIPTION
"random" but no "ground truth" tests failed on edge cases.

When the sought element is smaller than all search library numbers, method 2 yields a 0, whereas `searchsortedprevious` yields a 1 (first element in the library). Likewise, for the next method, if it's largest than all elements, `searchsortedfirst` will give a number that is one larger than the total set length(a)+1.

Forgot to place bounds on the second method when the test element is either larger than all elements in the search list `a` or smaller than all elements `a`. 